### PR TITLE
Harden the definition of Make to avoid issues in usages of the library when Stdlib.Set.S changes

### DIFF
--- a/BitMaskSet.ml
+++ b/BitMaskSet.ml
@@ -110,8 +110,14 @@ module Int64 =
 (* ********************************************************************************************** *
  * Make functor.                                                                                  *
  * ********************************************************************************************** *)
-module Make(Mask : BitMask) =
-  struct
+module Make(Mask : BitMask) : sig
+    include S
+      with type storage = Mask.storage
+       and type t = Mask.storage
+       and type elt := Mask.t
+
+    val create : storage -> t
+  end = struct
     type storage = Mask.storage
     type t = Mask.storage
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+????-??-?? David Allsopp <david.allsopp -at- metastack.dot.com>
+  Version 1.2.1
+* Harden build against Stdlib.Set.S changing (@kit-ty-kate)
+
 2020-07-15 David Allsopp <david.allsopp -at- metastack.dot.com>
   Version 1.2.0
 * Migrate build system to Dune


### PR DESCRIPTION
https://github.com/ocaml/opam-repository/pull/16824/files#r455564178 shows that this library should not be allowed to compile when the interface of `Stdlib.Set.S` changes as it will make users of the library fail anyway.